### PR TITLE
feat(skills): add manage-service Claude Code skill

### DIFF
--- a/.claude/skills/manage-service/SKILL.md
+++ b/.claude/skills/manage-service/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: manage-service
+description: This skill should be used when the user asks to "start postgres", "spin up redis", "run kafka", "stop the service", "bring down mysql", "restart elasticsearch", "check status of a container", "start X with a custom port/password/etc", or otherwise wants to start, stop, restart, or configure any service under services/ in the easy-containers repo. Handles env.sample -> .env creation and applies custom env var overrides (port, credentials, version tag) before starting.
+---
+
+Manage the Docker Compose services defined under `services/<name>/` in this repo (postgres, redis, kafka, elasticsearch, etc.). Each service directory has a `docker-compose.yml` and, for services needing credentials/config, an `env.sample`.
+
+## Core workflow
+
+1. Identify the target service name. It must match a directory under `services/`. List them with `ls services/` if unsure.
+2. Identify the action: start (`up`), stop (`down`), `restart`, `logs`, or `status`.
+3. Identify any custom env vars the user wants (port, password, version tag, db name, etc.) by reading `services/<name>/env.sample` if it exists — that file lists every overridable variable and its default.
+4. Run the bundled script instead of hand-rolling `docker compose` + `sed` commands:
+
+```bash
+.claude/skills/manage-service/scripts/run-service.sh <service> <action> [KEY=VALUE ...]
+```
+
+Examples:
+
+```bash
+# Start postgres with defaults
+.claude/skills/manage-service/scripts/run-service.sh postgres up
+
+# Start postgres on a custom port with a custom password
+.claude/skills/manage-service/scripts/run-service.sh postgres up POSTGRES_PORT=5555 POSTGRES_PASSWORD=secret123
+
+# Stop redis
+.claude/skills/manage-service/scripts/run-service.sh redis down
+
+# Restart kafka with a different tag
+.claude/skills/manage-service/scripts/run-service.sh kafka restart KAFKA_TAG=3.7
+
+# Wipe volumes too (destructive - confirm with user first)
+.claude/skills/manage-service/scripts/run-service.sh postgres down --volumes
+
+# Check running containers for a service
+.claude/skills/manage-service/scripts/run-service.sh postgres status
+
+# Tail logs
+.claude/skills/manage-service/scripts/run-service.sh postgres logs
+```
+
+## What the script does
+
+- Creates `.env` from `env.sample` on first run if `.env` doesn't exist yet (services without `env.sample`, e.g. redis/nginx/kafka, need no `.env`).
+- For each `KEY=VALUE` argument, updates the existing line in `.env` if present, else appends it. This lets a service run with a non-default port, password, image tag, etc. without editing files by hand.
+- Runs the matching `docker compose` subcommand from inside `services/<name>/` and prints `docker compose ps` after `up`/`restart` so the user sees exposed ports immediately.
+
+## Guidance
+
+- Before overriding a var, check `env.sample` (or the `${VAR:-default}` interpolations in `docker-compose.yml`) to confirm the exact variable name expected — names are inconsistent across services (e.g. `POSTGRES_PORT` vs `MONGO_PORT` vs `KAFKA_TAG`).
+- `down --volumes` deletes persisted data (e.g. Postgres data volume) — confirm with the user before running it, per this repo's destructive-action norms.
+- Multiple services can run simultaneously since each has isolated named volumes and configurable host ports — reuse this script per service if the user wants a multi-service stack (e.g. postgres + redis).
+- If `docker compose` is not available, tell the user to start Docker Desktop or Colima (`colima start --cpu 2 --memory 4 --disk 20`) per `README.md`.
+
+## If the requested var isn't in env.sample yet
+
+`.env` accepts any `KEY=VALUE` line, but it only affects the container if `docker-compose.yml` actually references `${KEY}` somewhere (port mapping, `image: img:${KEY}`, `environment:`, `command:`, etc.).
+
+- **Var name exists in docker-compose.yml but not in env.sample** (sample is just incomplete): the script's override still works — it appends the line to `.env`. Optionally also add it to `env.sample` with its default so future runs are documented.
+- **Var doesn't appear in docker-compose.yml at all**: setting it in `.env` is a no-op. Edit `docker-compose.yml` first to reference `${NEW_VAR:-default}` in the right place (env var, port, image tag, volume path), add the same line to `env.sample`, then rerun the script with the override.

--- a/.claude/skills/manage-service/scripts/run-service.sh
+++ b/.claude/skills/manage-service/scripts/run-service.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Start/stop/inspect an easy-containers service, applying env overrides.
+#
+# Usage:
+#   run-service.sh <service> up   [KEY=VALUE ...]
+#   run-service.sh <service> down
+#   run-service.sh <service> restart [KEY=VALUE ...]
+#   run-service.sh <service> logs
+#   run-service.sh <service> status
+#   run-service.sh <service> down --volumes   # down + wipe volumes
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+SERVICE="${1:-}"
+ACTION="${2:-}"
+shift 2 || true
+
+if [[ -z "$SERVICE" || -z "$ACTION" ]]; then
+  echo "Usage: run-service.sh <service> <up|down|restart|logs|status> [KEY=VALUE ...]" >&2
+  exit 1
+fi
+
+SERVICE_DIR="$REPO_ROOT/services/$SERVICE"
+if [[ ! -d "$SERVICE_DIR" ]]; then
+  echo "Error: no such service '$SERVICE' under services/" >&2
+  echo "Available: $(ls "$REPO_ROOT/services")" >&2
+  exit 1
+fi
+
+cd "$SERVICE_DIR"
+
+# Materialize .env on first run (from env.sample if present, else empty).
+# docker compose auto-loads .env for ${VAR} substitution in docker-compose.yml
+# even when the service has no env_file directive, so this works for every
+# service, not just ones that ship an env.sample.
+if [[ ! -f .env ]]; then
+  if [[ -f env.sample ]]; then
+    cp env.sample .env
+    echo "Created .env from env.sample in services/$SERVICE"
+  else
+    touch .env
+  fi
+fi
+
+# Apply KEY=VALUE overrides passed as remaining args, e.g. POSTGRES_PORT=5555.
+# Any var name works here, even ones not listed in env.sample: if the key
+# already has a line in .env it's updated in place, otherwise a new line is
+# appended. New vars only take effect if docker-compose.yml actually
+# references them (as ${VAR} or ${VAR:-default}) - add that reference to
+# docker-compose.yml first if it's missing.
+for kv in "$@"; do
+  [[ "$kv" == --* ]] && continue
+  key="${kv%%=*}"
+  val="${kv#*=}"
+  if grep -q "^${key}=" .env; then
+    sed -i.bak "s|^${key}=.*|${key}=${val}|" .env && rm -f .env.bak
+  else
+    echo "${key}=${val}" >> .env
+  fi
+done
+
+case "$ACTION" in
+  up)
+    docker compose up -d
+    docker compose ps
+    ;;
+  down)
+    if [[ " $* " == *" --volumes "* ]]; then
+      docker compose down -v
+    else
+      docker compose down
+    fi
+    ;;
+  restart)
+    docker compose down
+    docker compose up -d
+    docker compose ps
+    ;;
+  logs)
+    docker compose logs -f --tail=100
+    ;;
+  status|ps)
+    docker compose ps
+    ;;
+  *)
+    echo "Unknown action: $ACTION" >&2
+    exit 1
+    ;;
+esac

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 
 # Temporary files
 tmp/
+
+# Personal Claude Code settings (keep .claude/skills/ tracked)
+.claude/settings.local.json


### PR DESCRIPTION
Lets Claude start/stop/restart any services/<name> container, auto-creating .env from env.sample and applying custom env var overrides (port, password, version tag) before running docker compose.

Smart-Commit: fast-mode

## What does this PR add or change?

## Checklist

- [ ] Docker Compose starts successfully
- [ ] README added/updated
- [ ] No secrets committed
- [ ] Intended for local development only

## Related issue

(Optional)
